### PR TITLE
Improve presentation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Presentation Generator API
+
+This repository contains a simple FastAPI service for generating PDF presentations from JSON data.
+
+## Setup
+1. Install the required packages:
+   ```bash
+   python3 -m pip install -r requirements.txt
+   ```
+2. Run the service:
+   ```bash
+   python app.py
+   ```
+   The service will start on `0.0.0.0:8000` by default.
+   Open `http://localhost:8000/` in your browser for a simple web interface.
+
+## Endpoints
+- `POST /create_presentation` – Accepts presentation data and returns a PDF file.
+- `GET /health` – Basic health check that returns `{"status": "OK"}`.
+- `GET /` – Simple HTML interface to submit presentation requests.
+
+## Request Format
+Example payload for `/create_presentation`:
+```json
+{
+  "title": "AI Trends 2025",
+  "slides": [
+    {
+      "slide_title": "Introduction",
+      "slide_text": "In this presentation, we will cover the top AI trends for 2025.",
+      "image_url": "https://example.com/ai-intro.png"
+    }
+  ]
+}
+```

--- a/a
+++ b/a
@@ -1,4 +1,0 @@
-echo "# My Project" > README.md
-git add README.md
-git commit -m "init"
-git push

--- a/app.py
+++ b/app.py
@@ -1,0 +1,105 @@
+"""FastAPI service to generate PDF presentations from JSON data."""
+
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import StreamingResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, validator
+from typing import List, Optional
+import io
+import requests
+from reportlab.lib.pagesizes import landscape, letter
+from reportlab.pdfgen import canvas
+
+# Pydantic models for request validation
+class Slide(BaseModel):
+    slide_title: str
+    slide_text: str
+    image_url: Optional[str] = None
+
+class PresentationRequest(BaseModel):
+    title: str
+    slides: List[Slide]
+
+    @validator('slides')
+    def check_slides(cls, v):
+        if not v:
+            raise ValueError('slides must not be empty')
+        return v
+
+app = FastAPI()
+app.mount('/static', StaticFiles(directory='static'), name='static')
+
+
+@app.get('/', response_class=HTMLResponse)
+def root():
+    """Serve a simple HTML page for creating presentations."""
+    with open('static/index.html', 'r', encoding='utf-8') as file:
+        return file.read()
+
+
+def generate_pdf(data: PresentationRequest) -> io.BytesIO:
+    """Create a PDF in memory from the presentation data."""
+    buffer = io.BytesIO()
+    pdf = canvas.Canvas(buffer, pagesize=landscape(letter))
+    width, height = landscape(letter)
+
+    for slide in data.slides:
+        pdf.setFont('Helvetica-Bold', 24)
+        pdf.drawString(40, height - 50, slide.slide_title)
+
+        pdf.setFont('Helvetica', 14)
+        text_object = pdf.beginText(40, height - 100)
+        for line in slide.slide_text.split('\n'):
+            text_object.textLine(line)
+        pdf.drawText(text_object)
+
+        if slide.image_url:
+            try:
+                response = requests.get(slide.image_url, timeout=5)
+                response.raise_for_status()
+                image_data = io.BytesIO(response.content)
+                pdf.drawImage(
+                    image_data,
+                    width - 340,
+                    50,
+                    width=300,
+                    preserveAspectRatio=True,
+                    mask='auto'
+                )
+            except requests.RequestException:
+                # Ignore image errors and continue without it
+                pass
+        pdf.showPage()
+
+    pdf.save()
+    buffer.seek(0)
+    return buffer
+
+@app.get('/health')
+def health_check():
+    """Simple health check endpoint."""
+    return {'status': 'OK'}
+
+@app.post('/create_presentation')
+def create_presentation(data: PresentationRequest):
+    """Generate a PDF presentation from the provided data."""
+    try:
+        buffer = generate_pdf(data)
+        headers = {
+            'Content-Disposition': f'attachment; filename="{data.title}.pdf"'
+        }
+        return StreamingResponse(
+            buffer,
+            media_type='application/pdf',
+            headers=headers
+        )
+
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+if __name__ == "__main__":
+    # Allow the service to be run directly with `python app.py`
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+uvicorn
+reportlab
+requests

--- a/static/index.html
+++ b/static/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Presentation Generator</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 20px; }
+        .slide { border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; }
+    </style>
+</head>
+<body>
+    <h1>Create Presentation</h1>
+    <label>Title: <input type="text" id="title"></label>
+    <div id="slides"></div>
+    <button id="addSlide">Add Slide</button>
+    <button id="submit">Create PDF</button>
+    <script src="/static/script.js"></script>
+</body>
+</html>

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,44 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const slidesDiv = document.getElementById('slides');
+    const addSlideBtn = document.getElementById('addSlide');
+    const submitBtn = document.getElementById('submit');
+
+    function addSlide() {
+        const slideDiv = document.createElement('div');
+        slideDiv.className = 'slide';
+        slideDiv.innerHTML = `
+            <label>Slide Title: <input type="text" class="slide_title"></label><br>
+            <label>Slide Text:<br><textarea class="slide_text"></textarea></label><br>
+            <label>Image URL: <input type="text" class="image_url"></label>
+        `;
+        slidesDiv.appendChild(slideDiv);
+    }
+
+    addSlideBtn.addEventListener('click', addSlide);
+    addSlide();
+
+    submitBtn.addEventListener('click', async () => {
+        const title = document.getElementById('title').value;
+        const slides = Array.from(document.querySelectorAll('.slide')).map(slide => ({
+            slide_title: slide.querySelector('.slide_title').value,
+            slide_text: slide.querySelector('.slide_text').value,
+            image_url: slide.querySelector('.image_url').value || undefined
+        }));
+        const response = await fetch('/create_presentation', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ title, slides })
+        });
+        if (response.ok) {
+            const blob = await response.blob();
+            const url = window.URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = title + '.pdf';
+            a.click();
+            window.URL.revokeObjectURL(url);
+        } else {
+            alert('Failed to create presentation');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add usage instructions in `README.md`
- specify dependencies in `requirements.txt`
- factor PDF generation into `generate_pdf` helper
- support running with `python app.py`
- remove unused helper file
- add web interface for creating presentations

## Testing
- `python3 -m pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python3 app.py` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_685c5270f9e4832883fca9537d6c977f